### PR TITLE
Filter improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 uniemoji.db
 *~
+*.pyc

--- a/uniemoji.py
+++ b/uniemoji.py
@@ -25,7 +25,6 @@ from __future__ import print_function
 from gi.repository import IBus
 from gi.repository import GLib
 from gi.repository import GObject
-from gi.repository import Pango
 
 import os
 import sys
@@ -244,9 +243,7 @@ class UniEmoji(IBus.Engine):
             if query == candidate:
                 matched.append([2, 0, candidate])
             else:
-                level = 0
                 score = 0
-                ops = []
                 if Levenshtein is None:
                     opcodes = SequenceMatcher(None, query, candidate,
                         autojunk=False).get_opcodes()
@@ -260,8 +257,6 @@ class UniEmoji(IBus.Engine):
                         score -= 1
                     if tag == 'equal':
                         score += i2 - i1
-                        if i2 - i1 == len(query):
-                            level = 1
                         # favor word boundaries
                         if j1 == 0:
                             score += 2
@@ -372,7 +367,7 @@ def main():
 
     try:
         opts, args = getopt.getopt(sys.argv[1:], shortopt, longopt)
-    except getopt.GetoptError, err:
+    except getopt.GetoptError:
         print_help(sys.stderr, 1)
 
     for o, a in opts:


### PR DESCRIPTION
First of all, I cleaned up some of the warnings I got from Pyflakes about unused imports and variables, and added *.pyc to .gitignore, since I tested it with a local script instead of "installing" it each time.

I did the following improvements for the filter:
* Substring matches are ranked just below exact matches, before all the Levenshtein distance stuff. This means that searching for "rice" actually gives you top results with "rice" in them instead of "right".
* If the query is multiple words, I do the substring search for each word separately, so you could enter words in the reverse order. Note, however, that I didn't do a substring search on each word in the candidate - I fear that may be a bit too slow. (so "rice ball" matched with "rice ball" gives the indexes 0 and 5 instead of 0 and 0)